### PR TITLE
Minor UX Improvements

### DIFF
--- a/example_instancestack.yaml
+++ b/example_instancestack.yaml
@@ -298,7 +298,7 @@ Resources:
             - FILE=$(mktemp) && echo $FILE && echo '#!/bin/bash' > $FILE && echo 'reboot -f --verbose' >> $FILE && at now + 1 minute -f $FILE
             - echo "Bootstrap completed with return code $?"
   
-  ExampleC9BootstrapAssoziation: 
+  ExampleC9BootstrapAssociation: 
     Type: AWS::SSM::Association
     DependsOn: ExampleC9OutputBucket 
     Properties: 
@@ -322,7 +322,7 @@ Resources:
 
   ExampleC9Instance:
     Description: "-"
-    DependsOn: ExampleC9BootstrapAssoziation
+    DependsOn: ExampleC9BootstrapAssociation
     Type: AWS::Cloud9::EnvironmentEC2
     Properties:
       Description: AWS Cloud9 instance for Examples

--- a/example_instancestack.yaml
+++ b/example_instancestack.yaml
@@ -24,6 +24,7 @@ Parameters:
   ExampleOwnerArn: 
     Type: String
     Description: The Arn of the Cloud9 Owner to be set if 3rdParty deployment.
+    Default: ""
   ExampleC9InstanceVolumeSize: 
     Type: Number
     Description: The Size in GB of the Cloud9 Instance Volume. 

--- a/example_setup.sh
+++ b/example_setup.sh
@@ -14,8 +14,13 @@ if ! [ -x "$(command -v aws)" ]; then
   exit 1
 fi
 
-export AWS_PROFILE=$PROFILE
-export AWS_DEFAULT_REGION=$REGION
+if [ ! -z  "$PROFILE" ]; then
+  export AWS_PROFILE=$PROFILE
+fi
+
+if [ ! -z "$REGION" ]; then
+  export AWS_DEFAULT_REGION=$REGION
+fi
 
 echo Building $PROFILE C9
 


### PR DESCRIPTION
*Description of changes:*

This pull-request is related to 3 minor improvements:

- Added default value for the `ExampleOwnerArn` parameter in the file `example_instancestack.yaml` to avoid the error:

```
An error occurred (ValidationError) when calling the CreateChangeSet operation: Parameters: [ExampleOwnerArn] must have values
```

- Added conditional logic for exports of environment variables `AWS_PROFILE` and `AWS_DEFAULT_REGION` in the file `example_setup.sh`, to reuse user's existing variables and avoid the error below when running the `example_setup.sh` without any argument:

```
The config profile () could not be found
```

- Minor typo in the name of resource, from `ExampleC9BootstrapAssoziation` to `ExampleC9BootstrapAssociation`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
