### PR TITLE
Add Deletion Handler for custom resource

### DIFF
--- a/example_instancestack.yaml
+++ b/example_instancestack.yaml
@@ -158,6 +158,10 @@ Resources:
               responseData = {}
 
               status = cfnresponse.SUCCESS
+              
+              if event['RequestType'] == 'Delete':
+                  responseData = {'Success': 'Custom Resource removed'}
+                  cfnresponse.send(event, context, status, responseData, 'CustomResourcePhysicalID')              
           
               if event['RequestType'] == 'Create':
                   try:


### PR DESCRIPTION
Added deletion handler for custom resource to prevent CFN to wait for a response on Stack deletion

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
