### PR TITLE
add Cloud9 instance reboot after InstanceProfile is assigned

### DIFF
--- a/example_instancestack.yaml
+++ b/example_instancestack.yaml
@@ -93,6 +93,7 @@ Resources:
             - ec2:AssociateIamInstanceProfile
             - ec2:ModifyInstanceAttribute
             - ec2:ReplaceIamInstanceProfileAssociation
+            - ec2:RebootInstances
             - iam:ListInstanceProfiles
             - iam:PassRole
             Resource: "*"
@@ -191,6 +192,8 @@ Resources:
                       response = ec2.associate_iam_instance_profile(IamInstanceProfile=iam_instance_profile, InstanceId=instance['InstanceId'])
                       # logger.info('response - associate_iam_instance_profile: {}'.format(response))
                       r_ec2 = boto3.resource('ec2')
+
+                      response = ec2.reboot_instances(InstanceIds=[instance['InstanceId']], DryRun=False)
   
                       responseData = {'Success': 'Started bootstrapping for instance: '+instance['InstanceId']}
                       cfnresponse.send(event, context, status, responseData, 'CustomResourcePhysicalID')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added Cloud9 instance reboot after custom resource Lambda assigns the InstanceProfile. Otherwise we have a delay up to 30 minutes between Cloud9 creation and start of SSM RunCommand to start an instance bootstrap. 
SSM Agent tried to connect to SSM after first start of Cloud9 instance, the instance doesn’t have any InstanceProfile yet, and it doesn’t have permissions to connect to SSM. When Lambda assigns the Instance profile and reboots Cloud9 instance, then SSM Agent can start an instance bootstrap.
/var/log/amazon/ssm/amazon-ssm-agent.log
…
ERROR EC2RoleProvider Failed to connect to Systems Manager with SSM role credentials. error calling RequestManagedInstanceRoleToken: **AccessDeniedException**: Systems Manager’s instance management role is not configured for account:
…
**2023-11-03 18:09:35 INFO [CredentialRefresher] Sleeping for 25m42s before retrying retrieve credentials**
2023-11-03 18:11:08 INFO [amazon-ssm-agent] amazon-ssm-agent got signal:terminated value:0x55bb24f94ca0
2023-11-03 18:11:08 INFO [amazon-ssm-agent] Received stop/termination signal from main routine
2023-11-03 18:11:08 INFO [amazon-ssm-agent] Stopping Core Agent
2023-11-03 18:11:32 INFO Proxy environment variables:
…
2023-11-03 18:11:32 INFO Agent will take identity from EC2
…
2023-11-03 18:11:32 INFO [EC2Identity] Registration info found for ec2 instance
2023-11-03 18:11:32 INFO [amazon-ssm-agent] Registration attempted. Resuming core agent startup.
2023-11-03 18:11:32 INFO [CredentialRefresher] credentialRefresher has started
2023-11-03 18:11:32 INFO [CredentialRefresher] Starting credentials refresher loop
2023-11-03 18:11:32 INFO EC2RoleProvider Successfully connected with instance profile role credentials
**2023-11-03 18:11:32 INFO [CredentialRefresher] Credentials ready**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
